### PR TITLE
Add interview analyzer web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# codex
+# Interview Analyzer
+
+This is a simple Flask web application that analyzes emotions in an interview video.
+
+## Features
+- Upload a video file of the interview.
+- Process the video using the [FER](https://github.com/justinshenk/fer) library to detect facial emotions.
+- Display a score for each emotion on a 0-10 scale and indicate pass/fail status.
+
+## Requirements
+See `requirements.txt` for Python dependencies. You can install them with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running
+
+```bash
+python app.py
+```
+
+Then open `http://localhost:5000` in your browser.

--- a/analysis.py
+++ b/analysis.py
@@ -1,0 +1,43 @@
+import cv2
+from fer import FER
+
+
+def analyze_emotions(video_path):
+    """Analyze emotions in a video using the FER library.
+
+    Returns a dictionary mapping emotions to scores out of 10.
+    The score is computed based on the average intensity of each emotion.
+    """
+    detector = FER(mtcnn=True)
+    cap = cv2.VideoCapture(video_path)
+
+    if not cap.isOpened():
+        raise ValueError(f"Cannot open video: {video_path}")
+
+    emotions_sum = {}
+    frame_count = 0
+
+    while True:
+        ret, frame = cap.read()
+        if not ret:
+            break
+        frame_count += 1
+        result = detector.detect_emotions(frame)
+        if not result:
+            continue
+        # result is a list of dicts; we take the first face detected
+        emotions = result[0]["emotions"]
+        for emotion, score in emotions.items():
+            emotions_sum[emotion] = emotions_sum.get(emotion, 0) + score
+
+    cap.release()
+
+    if frame_count == 0:
+        return {}
+
+    # Average and scale to 0-10
+    averaged = {
+        emotion: min(10, (value / frame_count) * 10)
+        for emotion, value in emotions_sum.items()
+    }
+    return averaged

--- a/app.py
+++ b/app.py
@@ -1,0 +1,40 @@
+from flask import Flask, render_template, request, redirect, url_for
+import os
+from analysis import analyze_emotions
+
+UPLOAD_FOLDER = 'uploads'
+ALLOWED_EXTENSIONS = {'mp4', 'avi', 'mov', 'mkv'}
+
+app = Flask(__name__)
+app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
+
+os.makedirs(UPLOAD_FOLDER, exist_ok=True)
+
+
+def allowed_file(filename):
+    return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
+
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+
+@app.route('/upload', methods=['POST'])
+def upload_file():
+    if 'file' not in request.files:
+        return redirect(url_for('index'))
+    file = request.files['file']
+    if file.filename == '' or not allowed_file(file.filename):
+        return redirect(url_for('index'))
+    filepath = os.path.join(app.config['UPLOAD_FOLDER'], file.filename)
+    file.save(filepath)
+
+    scores = analyze_emotions(filepath)
+    passed = all(score > 5 for score in scores.values()) if scores else False
+
+    return render_template('result.html', scores=scores, passed=passed)
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+opencv-python
+fer

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Interview Analyzer</title>
+</head>
+<body>
+    <h1>Interview Analyzer</h1>
+    <form action="/upload" method="post" enctype="multipart/form-data">
+        <input type="file" name="file" accept="video/*" required>
+        <button type="submit">Upload Video</button>
+    </form>
+</body>
+</html>

--- a/templates/result.html
+++ b/templates/result.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Analysis Result</title>
+</head>
+<body>
+    <h1>Analysis Result</h1>
+    {% if scores %}
+    <ul>
+        {% for emotion, score in scores.items() %}
+        <li>{{ emotion }}: {{ score | round(2) }}/10</li>
+        {% endfor %}
+    </ul>
+    <p>Status: <strong>{{ 'Pass' if passed else 'Fail' }}</strong></p>
+    {% else %}
+    <p>No faces detected.</p>
+    {% endif %}
+    <a href="/">Back</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- set up a simple Flask site for uploading interview videos
- add emotion analysis helper using the `fer` library
- render emotion scores and pass/fail result
- document how to run the app and dependencies

## Testing
- `python -m py_compile app.py analysis.py`

------
https://chatgpt.com/codex/tasks/task_e_684c1e96cf1c83278e2d60f50f192147