### PR TITLE
Add full audio and transcript analysis pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# codex
+# Interview Analyzer
+
+This is a simple Flask web application that analyzes emotions in an interview video.
+
+## Features
+- Upload a video file of the interview.
+- Process the video using the [FER](https://github.com/justinshenk/fer) library to detect facial emotions.
+- Extract the audio track and compute basic emotion features with **pyAudioAnalysis**.
+- Transcribe speech using **Whisper** and optionally send it to the OpenAI API for sincerity analysis.
+- Display a score for each emotion on a 0-10 scale and indicate pass/fail status.
+
+## Requirements
+See `requirements.txt` for Python dependencies. You can install them with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running
+
+```bash
+python app.py
+```
+
+Then open `http://localhost:5000` in your browser.

--- a/analysis.py
+++ b/analysis.py
@@ -1,0 +1,103 @@
+import os
+import cv2
+from fer import FER
+from moviepy.editor import VideoFileClip
+from pyAudioAnalysis import audioBasicIO, ShortTermFeatures
+import whisper
+import openai
+
+
+def extract_audio(video_path, audio_path="audio.wav"):
+    """Extract audio from video and save to a file."""
+    clip = VideoFileClip(video_path)
+    clip.audio.write_audiofile(audio_path)
+    return audio_path
+
+
+def analyze_emotions(video_path):
+    """Analyze emotions in a video using the FER library.
+
+    Returns a dictionary mapping emotions to scores out of 10 based on
+    average intensity over detected faces.
+    """
+    detector = FER(mtcnn=True)
+    cap = cv2.VideoCapture(video_path)
+
+    if not cap.isOpened():
+        raise ValueError(f"Cannot open video: {video_path}")
+
+    emotions_sum = {}
+    frame_count = 0
+
+    while True:
+        ret, frame = cap.read()
+        if not ret:
+            break
+        frame_count += 1
+        result = detector.detect_emotions(frame)
+        if not result:
+            continue
+        emotions = result[0]["emotions"]
+        for emotion, score in emotions.items():
+            emotions_sum[emotion] = emotions_sum.get(emotion, 0) + score
+
+    cap.release()
+
+    if frame_count == 0:
+        return {}
+
+    averaged = {
+        emotion: min(10, (value / frame_count) * 10)
+        for emotion, value in emotions_sum.items()
+    }
+    return averaged
+
+
+def analyze_audio_emotions(audio_path):
+    """Extract basic audio features as a proxy for emotion."""
+    [sr, signal] = audioBasicIO.read_audio_file(audio_path)
+    st_features, _ = ShortTermFeatures.feature_extraction(signal, sr,
+                                                         0.05 * sr,
+                                                         0.05 * sr)
+    energy = st_features[1].mean()
+    zcr = st_features[0].mean()
+    return {"energy": float(energy), "zcr": float(zcr)}
+
+
+def transcribe_audio(audio_path, model="base"):
+    """Transcribe speech in the audio using Whisper."""
+    whisper_model = whisper.load_model(model)
+    result = whisper_model.transcribe(audio_path)
+    return result["text"]
+
+
+def honesty_analysis(text, api_key=None):
+    """Send the text to OpenAI API for a sincerity analysis."""
+    key = api_key or os.environ.get("OPENAI_API_KEY")
+    if not key:
+        return "No API key provided."
+    openai.api_key = key
+    prompt = (
+        "Aşağıdaki konuşma metnini analiz et. Konuşma samimi mi? "
+        "Kişi dürüst mü konuşuyor gibi görünüyor mu?\n\nMetin:\n" + text
+    )
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return response.choices[0].message["content"].strip()
+
+
+def full_analysis(video_path, api_key=None):
+    """Run the full analysis pipeline on a video file."""
+    audio_path = extract_audio(video_path)
+    face_scores = analyze_emotions(video_path)
+    audio_scores = analyze_audio_emotions(audio_path)
+    transcript = transcribe_audio(audio_path)
+    honesty = honesty_analysis(transcript, api_key)
+    return {
+        "faces": face_scores,
+        "audio": audio_scores,
+        "transcript": transcript,
+        "honesty": honesty,
+    }

--- a/app.py
+++ b/app.py
@@ -1,0 +1,41 @@
+from flask import Flask, render_template, request, redirect, url_for
+import os
+from analysis import full_analysis
+
+UPLOAD_FOLDER = 'uploads'
+ALLOWED_EXTENSIONS = {'mp4', 'avi', 'mov', 'mkv'}
+
+app = Flask(__name__)
+app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
+
+os.makedirs(UPLOAD_FOLDER, exist_ok=True)
+
+
+def allowed_file(filename):
+    return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
+
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+
+@app.route('/upload', methods=['POST'])
+def upload_file():
+    if 'file' not in request.files:
+        return redirect(url_for('index'))
+    file = request.files['file']
+    if file.filename == '' or not allowed_file(file.filename):
+        return redirect(url_for('index'))
+    filepath = os.path.join(app.config['UPLOAD_FOLDER'], file.filename)
+    file.save(filepath)
+
+    results = full_analysis(filepath)
+    scores = results.get('faces', {})
+    passed = all(score > 5 for score in scores.values()) if scores else False
+
+    return render_template('result.html', results=results, passed=passed)
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+Flask
+opencv-python
+fer
+moviepy
+pyAudioAnalysis
+whisper
+openai

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Interview Analyzer</title>
+</head>
+<body>
+    <h1>Interview Analyzer</h1>
+    <form action="/upload" method="post" enctype="multipart/form-data">
+        <input type="file" name="file" accept="video/*" required>
+        <button type="submit">Upload Video</button>
+    </form>
+</body>
+</html>

--- a/templates/result.html
+++ b/templates/result.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Analysis Result</title>
+</head>
+<body>
+    <h1>Analysis Result</h1>
+    {% if results.faces %}
+    <ul>
+        {% for emotion, score in results.faces.items() %}
+        <li>{{ emotion }}: {{ score | round(2) }}/10</li>
+        {% endfor %}
+    </ul>
+    <p>Status: <strong>{{ 'Pass' if passed else 'Fail' }}</strong></p>
+    {% else %}
+    <p>No faces detected.</p>
+    {% endif %}
+    <h2>Audio Features</h2>
+    <ul>
+        {% for feature, value in results.audio.items() %}
+        <li>{{ feature }}: {{ value | round(2) }}</li>
+        {% endfor %}
+    </ul>
+    <h2>Transcript</h2>
+    <p>{{ results.transcript }}</p>
+    <h2>Honesty Analysis</h2>
+    <p>{{ results.honesty }}</p>
+    <a href="/">Back</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- extend requirements with audio and transcription packages
- extract audio from uploaded videos and compute emotion features
- transcribe audio and run honesty analysis via OpenAI API
- update result template to show audio features and transcript

## Testing
- `python -m py_compile app.py analysis.py`


------
https://chatgpt.com/codex/tasks/task_e_684c1e96cf1c83278e2d60f50f192147